### PR TITLE
Add a SetBot function so that users can identify as a bot

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -64,6 +64,7 @@ const (
 	userModify           = "user.modify"
 	userRemoveFan        = "user.remove_fan"
 	userSetAvatar        = "user.set_avatar"
+	userSetBot           = "user.set_bot"
 
 	// Valid statuses
 	available   = "available"

--- a/ttapi.go
+++ b/ttapi.go
@@ -554,6 +554,10 @@ func (b *Bot) setAvatar(avatarID int) error {
 	return txBaseErr(b, H{"api": userSetAvatar, "avatarid": avatarID})
 }
 
+func (b *Bot) setBot() error {
+	return txBaseErr(b, H{"api": userSetBot})
+}
+
 func (b *Bot) userAvailableAvatars() (out UserAvailableAvatarsRes, err error) {
 	b.tx(H{"api": userAvailableAvatars}, &out)
 	return out, baseErr(out.BaseRes)
@@ -950,6 +954,11 @@ func (b *Bot) ModifyLaptop(laptop string) error {
 // SetAvatar set your avatar
 func (b *Bot) SetAvatar(avatarID int) error {
 	return b.setAvatar(avatarID)
+}
+
+// SetBot makes your user a bot. WARNING: Once user is changed to a bot it cannot be undone!
+func (b *Bot) SetBot() error {
+	return b.setBot()
 }
 
 // UserAvailableAvatars get all available avatars


### PR DESCRIPTION
- turntable.fm allows for users to identify themselves as a bot through the API
- Adding a function to allow users of the library to set themselves as a bot (with the warning that once it is set it cannot be undone)
- Tested that this works on the bot I am making