### PR TITLE
Fix the stopSong() message to send all the necessary info to skip a song

### DIFF
--- a/ttapi.go
+++ b/ttapi.go
@@ -768,7 +768,7 @@ func (b *Bot) getPresence(userID string) (out GetPresenceRes, err error) {
 }
 
 func (b *Bot) stopSong() error {
-	return txBaseErr(b, H{"api": roomStopSong, "roomid": b.roomID})
+	return txBaseErr(b, H{"api": roomStopSong, "roomid": b.roomID, "djid": b.CurrentDjID, "songid": b.CurrentSongID})
 }
 
 func (b *Bot) skip() error {


### PR DESCRIPTION
- Found that I could not call stopSong() and have it succeed when another user was playing a song and the bot was a mod
- Put in these two fields to match what I see the web client is doing and now the bot based on this code can skip other user's songs