### PR TITLE
Parse the new field to tell if a user is a bot

### DIFF
--- a/data.go
+++ b/data.go
@@ -232,6 +232,7 @@ type RoomInfoRes struct {
 		ID         string  `json:"_id"`
 		Avatarid   int     `json:"avatarid"`
 		Registered float64 `json:"registered"`
+		Bot        bool    `json:"bot"`
 	} `json:"users"`
 }
 


### PR DESCRIPTION
- Noticed I could not tell if a user was a bot
- Checked in Chrome what call gives the bot info and found the library was not parsing this new field
- Checked with logs that we are now parsing the bot field correctly when calling `RoomInfo()`