### PR TITLE
Fix update presence to use the time returned from the server

### DIFF
--- a/ttapi.go
+++ b/ttapi.go
@@ -24,28 +24,29 @@ var lenRgx = regexp.MustCompile(`^~m~([0-9]+)~m~`)
 // To get the auth, user id and room id, you can use the following bookmarklet
 // http://alaingilbert.github.io/Turntable-API/bookmarklet.html
 type Bot struct {
-	auth            string                   // auth id, can be retrieved using bookmarklet
-	userID          string                   // user id, can be retrieved using bookmarklet
-	roomID          string                   // room id, can be retrieved using bookmarklet
-	client          string                   // web
-	laptop          string                   // mac
-	logWs           bool                     // either or not to log websocket messages
-	msgID           int                      // keep track of message id used to communicate with ws server
-	clientID        string                   // random string
-	currentStatus   string                   // available/unavailable/away used for the chat
-	lastHeartbeat   time.Time                // keep track of last heartbeat timestamp
-	lastActivity    time.Time                // keep track of last received message timestamp
-	ws              *websocket.Conn          // websocket connection to turntable
-	unackMsgs       []UnackMsg               // list of messages sent that are not acknowledged by the ws server
-	currentSearches []Search                 // Current searches in progress
-	callbacks       map[string][]interface{} // user defined callbacks set for each events
-	ctx             context.Context          // bot context
-	cancel          context.CancelFunc       // cancel function to stop bot
-	CurrentSongID   string                   // cached current song id
-	CurrentDjID     string                   // cached current dj id
-	tmpSong         H                        // cached song fake message, used to emit our own fake event (endsong)
-	txCh            chan TxMsg               // messages to transmit to turntable
-	rxCh            chan RxMsg               // messages received from turntable
+	auth                string                   // auth id, can be retrieved using bookmarklet
+	userID              string                   // user id, can be retrieved using bookmarklet
+	roomID              string                   // room id, can be retrieved using bookmarklet
+	client              string                   // web
+	laptop              string                   // mac
+	logWs               bool                     // either or not to log websocket messages
+	msgID               int                      // keep track of message id used to communicate with ws server
+	clientID            string                   // random string
+	currentStatus       string                   // available/unavailable/away used for the chat
+	lastHeartbeat       time.Time                // keep track of last heartbeat timestamp
+	lastActivity        time.Time                // keep track of last received message timestamp
+	ws                  *websocket.Conn          // websocket connection to turntable
+	unackMsgs           []UnackMsg               // list of messages sent that are not acknowledged by the ws server
+	currentSearches     []Search                 // Current searches in progress
+	callbacks           map[string][]interface{} // user defined callbacks set for each events
+	ctx                 context.Context          // bot context
+	cancel              context.CancelFunc       // cancel function to stop bot
+	CurrentSongID       string                   // cached current song id
+	CurrentDjID         string                   // cached current dj id
+	tmpSong             H                        // cached song fake message, used to emit our own fake event (endsong)
+	txCh                chan TxMsg               // messages to transmit to turntable
+	rxCh                chan RxMsg               // messages received from turntable
+	presenceTaskStarted bool                     // to tell if we are already responding to a presence update
 }
 
 // NewBot creates a new bot
@@ -64,6 +65,7 @@ func NewBot(auth, userID, roomID string) *Bot {
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 	b.txCh = make(chan TxMsg, 10)
 	b.rxCh = make(chan RxMsg, 10)
+	b.presenceTaskStarted = false
 	return b
 }
 
@@ -181,7 +183,6 @@ func (b *Bot) processHeartbeat(data []byte) {
 	payload := `~m~` + strconv.Itoa(len(heartbeatID)) + `~m~` + heartbeatID
 	_, _ = b.ws.Write([]byte(payload))
 	b.lastHeartbeat = time.Now()
-	SGo(func() { _ = b.updatePresence() })
 }
 
 func (b *Bot) processCommand(rawJson []byte, jsonHashMap map[string]interface{}) {
@@ -285,6 +286,16 @@ func (b *Bot) executeCallback(rawJson []byte, jsonHashMap map[string]interface{}
 							b.currentSearches = append(b.currentSearches, Search{Query: query, Callback: unackMsg.Callback})
 						}
 					}
+				case presenceUpdate:
+					if success, ok := jsonHashMap["success"].(bool); ok && success {
+						if interval, ok := jsonHashMap["interval"].(float64); ok {
+							b.updatePresenceTask(interval)
+						} else {
+							b.updatePresenceTask(10.0)
+						}
+					} else {
+						b.updatePresenceTask(10.0)
+					}
 				}
 
 				// Execute callback if provided
@@ -302,6 +313,22 @@ func (b *Bot) executeCallback(rawJson []byte, jsonHashMap map[string]interface{}
 
 func (b *Bot) setTmpSong(room map[string]interface{}) {
 	b.tmpSong = H{"command": endsong, "room": room, "success": true}
+}
+
+func (b *Bot) updatePresenceTask(interval float64) {
+	// Only let one of these be running at a time
+	if !b.presenceTaskStarted {
+		b.presenceTaskStarted = true
+		SGo(func() {
+			select {
+			case <-time.After(time.Duration(interval) * time.Second):
+			case <-b.ctx.Done():
+				return
+			}
+			b.presenceTaskStarted = false
+			_ = b.updatePresence()
+		})
+	}
 }
 
 // Extract message length. eg: `~m~457~m~` -> 457


### PR DESCRIPTION
- Found that the original fix for #3 reverted here stopped working after keeping a bot online for > 24 hours (I would see bot showing offline then online again)
- Tried this way of starting a new presence update task anytime we get a presence update response
- Tried over the long weekend and the bot is still staying online after over 72 hours without it showing the bot going offline