### PR TITLE
Correct presenceTaskStarted default and always reset to zero

### DIFF
--- a/ttapi.go
+++ b/ttapi.go
@@ -315,16 +315,15 @@ func (b *Bot) setTmpSong(room map[string]interface{}) {
 
 func (b *Bot) updatePresenceTask(interval float64) {
 	// Only let one of these be running at a time
-	if newValue := atomic.AddInt32(&b.presenceTaskQueue, 1); newValue == 1 {
+	if c := atomic.AddInt32(&b.presenceTaskQueue, 1); c == 1 {
 		SGo(func() {
-			curValue := atomic.LoadInt32(&b.presenceTaskQueue)
 			// loop until expected updates have been called
-			for curValue > 0 {
+			for c > 0 {
 				// wait interval
 				<-time.After(time.Duration(interval) * time.Second)
 				_ = b.updatePresence()
 				// decrement counter and see if a run is still needed
-				curValue = atomic.AddInt32(&b.presenceTaskQueue, -1)
+				c = atomic.AddInt32(&b.presenceTaskQueue, -1)
 			}
 		})
 	}

--- a/ttapi.go
+++ b/ttapi.go
@@ -317,14 +317,10 @@ func (b *Bot) updatePresenceTask(interval float64) {
 	// Only let one of these be running at a time
 	if atomic.CompareAndSwapInt32(&b.presenceTaskStarted, 0, 1) {
 		SGo(func() {
-			defer func() {
+			SGo(func() {
+				<-time.After(time.Duration(interval) * time.Second)
 				atomic.StoreInt32(&b.presenceTaskStarted, 0)
-			}()
-			select {
-			case <-time.After(time.Duration(interval) * time.Second):
-			case <-b.ctx.Done():
-				return
-			}
+			})
 			_ = b.updatePresence()
 		})
 	}

--- a/ttapi.go
+++ b/ttapi.go
@@ -320,7 +320,7 @@ func (b *Bot) updatePresenceTask(interval float64) {
 			// loop until expected updates have been called
 			for c > 0 {
 				// wait interval
-				<-time.After(time.Duration(interval) * time.Second)
+				time.Sleep(time.Duration(interval) * time.Second)
 				_ = b.updatePresence()
 				// decrement counter and see if a run is still needed
 				c = atomic.AddInt32(&b.presenceTaskQueue, -1)

--- a/ttapi.go
+++ b/ttapi.go
@@ -25,29 +25,29 @@ var lenRgx = regexp.MustCompile(`^~m~([0-9]+)~m~`)
 // To get the auth, user id and room id, you can use the following bookmarklet
 // http://alaingilbert.github.io/Turntable-API/bookmarklet.html
 type Bot struct {
-	auth                string                   // auth id, can be retrieved using bookmarklet
-	userID              string                   // user id, can be retrieved using bookmarklet
-	roomID              string                   // room id, can be retrieved using bookmarklet
-	client              string                   // web
-	laptop              string                   // mac
-	logWs               bool                     // either or not to log websocket messages
-	msgID               int                      // keep track of message id used to communicate with ws server
-	clientID            string                   // random string
-	currentStatus       string                   // available/unavailable/away used for the chat
-	lastHeartbeat       time.Time                // keep track of last heartbeat timestamp
-	lastActivity        time.Time                // keep track of last received message timestamp
-	ws                  *websocket.Conn          // websocket connection to turntable
-	unackMsgs           []UnackMsg               // list of messages sent that are not acknowledged by the ws server
-	currentSearches     []Search                 // Current searches in progress
-	callbacks           map[string][]interface{} // user defined callbacks set for each events
-	ctx                 context.Context          // bot context
-	cancel              context.CancelFunc       // cancel function to stop bot
-	CurrentSongID       string                   // cached current song id
-	CurrentDjID         string                   // cached current dj id
-	tmpSong             H                        // cached song fake message, used to emit our own fake event (endsong)
-	txCh                chan TxMsg               // messages to transmit to turntable
-	rxCh                chan RxMsg               // messages received from turntable
-	presenceTaskStarted int32                    // atomic value to tell if we are already responding to a presence update
+	auth              string                   // auth id, can be retrieved using bookmarklet
+	userID            string                   // user id, can be retrieved using bookmarklet
+	roomID            string                   // room id, can be retrieved using bookmarklet
+	client            string                   // web
+	laptop            string                   // mac
+	logWs             bool                     // either or not to log websocket messages
+	msgID             int                      // keep track of message id used to communicate with ws server
+	clientID          string                   // random string
+	currentStatus     string                   // available/unavailable/away used for the chat
+	lastHeartbeat     time.Time                // keep track of last heartbeat timestamp
+	lastActivity      time.Time                // keep track of last received message timestamp
+	ws                *websocket.Conn          // websocket connection to turntable
+	unackMsgs         []UnackMsg               // list of messages sent that are not acknowledged by the ws server
+	currentSearches   []Search                 // Current searches in progress
+	callbacks         map[string][]interface{} // user defined callbacks set for each events
+	ctx               context.Context          // bot context
+	cancel            context.CancelFunc       // cancel function to stop bot
+	CurrentSongID     string                   // cached current song id
+	CurrentDjID       string                   // cached current dj id
+	tmpSong           H                        // cached song fake message, used to emit our own fake event (endsong)
+	txCh              chan TxMsg               // messages to transmit to turntable
+	rxCh              chan RxMsg               // messages received from turntable
+	presenceTaskQueue int32                    // atomic value to tell if we are already responding to a presence update
 }
 
 // NewBot creates a new bot
@@ -66,7 +66,7 @@ func NewBot(auth, userID, roomID string) *Bot {
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 	b.txCh = make(chan TxMsg, 10)
 	b.rxCh = make(chan RxMsg, 10)
-	b.presenceTaskStarted = 0
+	b.presenceTaskQueue = 0
 	return b
 }
 
@@ -315,13 +315,17 @@ func (b *Bot) setTmpSong(room map[string]interface{}) {
 
 func (b *Bot) updatePresenceTask(interval float64) {
 	// Only let one of these be running at a time
-	if atomic.CompareAndSwapInt32(&b.presenceTaskStarted, 0, 1) {
+	if newValue := atomic.AddInt32(&b.presenceTaskQueue, 1); newValue == 1 {
 		SGo(func() {
-			SGo(func() {
+			curValue := atomic.LoadInt32(&b.presenceTaskQueue)
+			// loop until expected updates have been called
+			for curValue > 0 {
+				// wait interval
 				<-time.After(time.Duration(interval) * time.Second)
-				atomic.StoreInt32(&b.presenceTaskStarted, 0)
-			})
-			_ = b.updatePresence()
+				_ = b.updatePresence()
+				// decrement counter and see if a run is still needed
+				curValue = atomic.AddInt32(&b.presenceTaskQueue, -1)
+			}
 		})
 	}
 }

--- a/ttapi.go
+++ b/ttapi.go
@@ -66,7 +66,7 @@ func NewBot(auth, userID, roomID string) *Bot {
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 	b.txCh = make(chan TxMsg, 10)
 	b.rxCh = make(chan RxMsg, 10)
-	b.presenceTaskStarted = false
+	b.presenceTaskStarted = 0
 	return b
 }
 


### PR DESCRIPTION
Dropping the `ctx.Done()` wait from the previous logic because even if the bot is `Stop()`-ed (and therefore the context channel closed), there's probably still value in waiting until `interval` has elapsed before allowing a new presence update to happen, should the both be restarted.