### PR TITLE
Adds API support for detecting server timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ func main() {
     })
 
     // callback if server stops responding after 5 minutes
-    timeoutDuration := time.Minute * 5)
+    timeoutDuration := time.Minute * 5
     bot.OnTimeout(timeoutDuration, func(evt ttapi.TimeoutEvt) { 
         logrus.Fatal("Server unresponsive")
     })

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ func main() {
             _ = bot.Speakf("Hey! How are you @%s ?", evt.Name)
         }
     })
+
+    // callback if server stops responding after 5 minutes
+    timeoutDuration := time.Minute * 5)
+    bot.OnTimeout(timeoutDuration, func(evt ttapi.TimeoutEvt) { 
+        logrus.Fatal("Server unresponsive")
+    })
+
     bot.Start()
 }
 ```

--- a/constants.go
+++ b/constants.go
@@ -85,4 +85,7 @@ const (
 	// Valid vote values
 	down = "down"
 	up   = "up"
+
+	// ttapi events
+	timeout = "ttapi_timeout"
 )

--- a/data.go
+++ b/data.go
@@ -1,5 +1,7 @@
 package ttapi
 
+import "time"
+
 // SpeakEvt struct received when someone speak in the public chat
 type SpeakEvt struct {
 	Command string
@@ -630,4 +632,12 @@ type NewModeratorEvt struct {
 	UserID  string `json:"userid"`
 	RoomID  string `json:"roomid"`
 	Success bool   `json:"success"`
+}
+
+// TimeoutEvt struct emitted when OnTimeout threshhold is reached
+type TimeoutEvt struct {
+	LastHeartbeat time.Time     `json:"lastHeartbeat"`
+	HeartbeatAge  time.Duration `json:"heartbeatAge"`
+	LastActivity  time.Time     `json:"lastActivity"`
+	ActivityAge   time.Duration `json:activityAge"`
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,5 +1,7 @@
 package ttapi
 
+import "time"
+
 // IBot ...
 type IBot interface {
 	On(cmd string, clb func([]byte))
@@ -19,6 +21,7 @@ type IBot interface {
 	OnSnagged(func(SnaggedEvt))
 	OnSpeak(func(SpeakEvt))
 	OnReady(func())
+	OnTimeout(time.Duration, func(TimeoutEvt))
 	OnUpdateUser(func([]byte))
 	OnUpdateVotes(func(UpdateVotesEvt))
 
@@ -70,6 +73,7 @@ type IBot interface {
 	UserModify(H) error
 	VoteDown() error
 	VoteUp() error
+	GetTimeoutInfo() (TimeoutEvt, error)
 }
 
 // Compile time checks to ensure type satisfies IBot interface


### PR DESCRIPTION
I'm having a problem recently where my bots will stop seeing updates from the server, but don't realize they are disconnected.  This PR adds a new callback hook `OnTimeout` to the API which will watch the internal `lastActivity` timestamp and emit a callback if no activity has been seen recently.  Also adds a helper `GetTimeoutInfo` method to the API to allow code to inspect and evaluate current heartbeat and activity data.

I tried to match your code style as best I could.  Happy to tweak or make adjustments if you think there's a cleaner way to implement this.