### PR TITLE
Add parsing modid field from add and remove moderator events since field was added to the API

### DIFF
--- a/data.go
+++ b/data.go
@@ -617,17 +617,21 @@ type EscortEvt struct {
 }
 
 // RemModeratorEvt ...
+// {"modid": "604173683f4bfc001c3a57d0", "roomid": "604064503f4bfc001be4c57b", "userid": "60b950ebb5178a0013a1e4a0", "command": "rem_moderator", "success": true}
 type RemModeratorEvt struct {
 	Command string `json:"command"`
 	UserID  string `json:"userid"`
 	RoomID  string `json:"roomid"`
 	Success bool   `json:"success"`
+	Modid   string `json:"modid"`
 }
 
 // NewModeratorEvt ...
+// {"modid": "604173683f4bfc001c3a57d0", "roomid": "604064503f4bfc001be4c57b", "userid": "60b950ebb5178a0013a1e4a0", "command": "new_moderator", "success": true}
 type NewModeratorEvt struct {
 	Command string `json:"command"`
 	UserID  string `json:"userid"`
 	RoomID  string `json:"roomid"`
 	Success bool   `json:"success"`
+	Modid   string `json:"modid"`
 }


### PR DESCRIPTION
- I asked Billy to add the `modid` field to the add/remove moderator events so bots can tell who did this mod action
- Tested the latest API exposes this new field and the library is parsing it correctly (also added a sample JSON response for each event as a comment)