### PR TITLE
Make sure the WS is closed properly

### DIFF
--- a/ttapi.go
+++ b/ttapi.go
@@ -79,6 +79,7 @@ func (b *Bot) startWS() {
 		logrus.Error("failed to dial websocket:", err)
 		return
 	}
+	defer b.ws.Close()
 	b.readWS()
 }
 


### PR DESCRIPTION
- For whatever reason after updating to the latest code if I call `Stop()` the bot does not actually leave the room
- Traced it down to the websocket staying open and found it is never explicitly closed
- Added closing the websocket and now the bot leaves correctly when `Stop()` is called