### PR TITLE
turntable.fm api domain and chat1.turntable.fm websocket domain depreciated 

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,8 +1,8 @@
 package ttapi
 
 const (
-	wsOrigin   = "https://turntable.fm"
-	wssURL     = "wss://chat1.turntable.fm:8080/socket.io/websocket"
+	wsOrigin   = "https://deepcut.fm"
+	wssURL     = "wss://chat1.deepcut.fm:8080/socket.io/websocket"
 	wsProtocol = ""
 
 	bootedUser     = "booted_user"


### PR DESCRIPTION
This PR rreplaces the depreciated turntable.fm api and socket urls with the current deepcut.fm urls. The turntable.fm urls will stop working after a cutover this weekend.